### PR TITLE
Version lock p5.play


### DIFF
--- a/game modules.md
+++ b/game modules.md
@@ -37,7 +37,7 @@ Open the side panel and open index.html
 Add the p5.play library by creating a new line after line 6 and pasting this code: 
 
 ```javascript
-<script src="https://cdn.rawgit.com/molleindustria/p5.play/master/lib/p5.play.js"></script>
+<script src="https://cdn.rawgit.com/molleindustria/p5.play/1bf3c72fe6b647617373b9b3ea3e419baaef8cfd/lib/p5.play.js"></script>
 ```
 
 Open the file sketch.js and close the side panel.  


### PR DESCRIPTION
Hey! I'm one of the engineers at [Hack Club](https://hackclub.com). Right now your site is broken because it links to the most recent version of p5.play.js, but when that updates your site won't work. I made this edit to set p5.play.js to a specific version so it won't update automatically (and should always work with your site).

Just click the "Merge" button that looks like this down below if you want to accept the edit:

![](https://i.imgur.com/Vz3I4Oi.png)

_This PR is created by a script for people who have completed Hack Club's workshops. If you think it was sent to you in error go ahead and click "close"._
